### PR TITLE
Missing RESET pin in screen constrcutor

### DIFF
--- a/sci_calc_code/src/Utils/Util.cpp
+++ b/sci_calc_code/src/Utils/Util.cpp
@@ -4,7 +4,7 @@ int lastNode = -1;
 
 // List of operators available in the calculator
 std::string tokenStr[MAXOP] = {"+", "-", "*", "/", "^", "sqrt", "ln", "exp", "sin", "cos", "tan", "sec", "csc", "cot", "asin", "acos", "atan", "(", ")", "=", "-", "NUM", "VAR"};
-U8G2_SSD1322_NHD_256X64_F_4W_HW_SPI u8g2(U8G2_R0, SPI_CS, SPI_DC);
+U8G2_SSD1322_NHD_256X64_F_4W_HW_SPI u8g2(U8G2_R0, SPI_CS, SPI_DC, SPI_RESET);
 
 
 bool sample = false;


### PR DESCRIPTION
The mssing RESET pin in u8g2 constructor may lead the OLED NOT to light up randomly.