### PR TITLE
Makes the checkbox filled when it should initially be checked, and also fixed some problem of stopwatch

### DIFF
--- a/sci_calc_code/src/Stopwatch/Stopwatch.cpp
+++ b/sci_calc_code/src/Stopwatch/Stopwatch.cpp
@@ -4,15 +4,25 @@ Stopwatch::Stopwatch() {
     this -> curTimeElapsed = 0;
     this -> startTime = 0;
     this -> timeBetweenIntervals = 0;
+    this -> pausedTime = 0;
+    this -> isPaused = false;
     this -> isTicking = false;
 }
 
 void Stopwatch::start() {
+    if (this -> isPaused) {
+        this -> startTime += millis() - this -> pausedTime;
+    } else {
+        this -> startTime = millis();
+    }
     this -> isTicking = true;
+    this -> isPaused = false;
 }
 
 void Stopwatch::pause() {
     this -> isTicking = false;
+    this -> isPaused = true;
+    this->pausedTime = millis();
 }
 
 int Stopwatch::lap() {
@@ -39,7 +49,9 @@ void Stopwatch::reset() {
     this -> startTime = millis();
     this -> curTimeElapsed = 0;
     this -> timeBetweenIntervals = 0;
+    this -> pausedTime = 0;
     this -> isTicking = false;
+    this -> isPaused = false;
 }
 
 bool Stopwatch::getIsTicking() {
@@ -53,7 +65,7 @@ void Stopwatch::update() {
         this -> curTimeElapsed += diff;
         this -> timeBetweenIntervals += diff;
     }
-    else {
+    else if(!this -> isPaused){
         this -> startTime = millis();
     }
 }

--- a/sci_calc_code/src/Stopwatch/Stopwatch.h
+++ b/sci_calc_code/src/Stopwatch/Stopwatch.h
@@ -29,7 +29,9 @@ class Stopwatch {
         int startTime;
         int curTimeElapsed;
         int timeBetweenIntervals;
+        int pausedTime;
         bool isTicking;
+        bool isPaused;
 };
 
 #endif

--- a/sci_calc_code/src/Stopwatch/StopwatchUI.cpp
+++ b/sci_calc_code/src/Stopwatch/StopwatchUI.cpp
@@ -55,7 +55,7 @@ void StopwatchUI::update() {
             //this -> lapMenu -> enter();
             UIElement* ptr = new Text(strres);
             ptr -> init();
-            this -> lapMenu -> insertElement(ptr, ptr);
+            this -> lapMenu -> insertElement(ptr, nullptr);
             this -> lapMenu -> scrollDown();
 
         }

--- a/sci_calc_code/src/UIElements/Checkbox.cpp
+++ b/sci_calc_code/src/UIElements/Checkbox.cpp
@@ -29,6 +29,7 @@ Checkbox::Checkbox(std::string name, int x, int y, bool* linkBool) {
 void Checkbox::init() {
     this -> width = this -> targetWidth = u8g2.getStrWidth(this -> name.c_str());
     this -> height = this -> targetHeight = 10;
+    this -> checkboxAni = (this -> state ? 6 : 0);
 }
 
 void Checkbox::activate() {

--- a/sci_calc_code/src/UIElements/Cursor.cpp
+++ b/sci_calc_code/src/UIElements/Cursor.cpp
@@ -1,22 +1,29 @@
 #include "Cursor.h"
 
 Cursor::Cursor() : UIElement(0, 0, 10, 12) {
+    this -> isVisible = true;
     this -> target = nullptr;
     this -> mode = 0;
 }
 
 Cursor::Cursor(bool mode) : UIElement(0, 0, 10, 12) {
+    this -> isVisible = true;
     this -> target = nullptr;
     this -> mode = mode;
 }
 
 Cursor::Cursor(UIElement* target, bool mode) : UIElement(0, 0, 10, 12) {
+    this -> isVisible = true;
     this -> target = target;
     this -> mode = mode;
 }
 
 void Cursor::setMode(bool mode) {
     this -> mode = mode;
+}
+
+void Cursor::setVisible(bool isVisible) {
+    this -> isVisible = isVisible;
 }
 
 void Cursor::changeTarget(UIElement* target) {
@@ -40,6 +47,9 @@ void Cursor::changeTarget(int x, int y, int width, int height, int time) {
 
 
 void Cursor::draw() {
+    if (this -> target == nullptr || ! this -> isVisible) {
+        return; //Don't draw cursor
+    }
     if (mode) {
         u8g2.drawLine(this -> x - 1, this -> y - 6 + 1, this -> x - 1, this -> y - 6 + this -> height - 3);
     }

--- a/sci_calc_code/src/UIElements/Cursor.h
+++ b/sci_calc_code/src/UIElements/Cursor.h
@@ -12,7 +12,7 @@ class Cursor : public UIElement {
         Cursor(UIElement* target, bool mode);
 
         void setMode(bool mode);
-
+        void setVisible(bool isVisible);
         void changeTarget(UIElement* target);
 
         void changeTarget(UIElement* target, int time);
@@ -25,6 +25,7 @@ class Cursor : public UIElement {
     private:
         UIElement* target;
         bool mode; // 0: box, 1: line
+        bool isVisible;
 };
 
 #endif

--- a/sci_calc_code/src/UIElements/Menu.cpp
+++ b/sci_calc_code/src/UIElements/Menu.cpp
@@ -103,8 +103,9 @@ void Menu::insertElement(UIElement* targetElement, UIElement* linkElement) {
     
     targetElement -> setX(this -> targetX + 5);
     targetElement -> setY(70);
+    this ->cursor.setVisible(true);
     insertAnimation(new Animation(targetElement, INDENT, targetElement -> getX(), min(this -> menuSize, int(this -> subElements.size())) * 12 + 12, 100));
-        
+    
     this -> subElements.push_back(targetElement);
     this -> linkElements.push_back(linkElement);
     targetElement -> init();
@@ -195,10 +196,12 @@ void Menu::clear() {
         this -> scrollBar.setHeight(0);
         this -> cursor.setX(this -> x);
         this -> cursor.setY(this -> y + 12);
+        this -> cursor.setVisible(false);
     }
     else {
         this -> scrollBar.setY(this -> y + 5 + (float(getMenuPos()) / float(this -> getSize()) * (this -> height - 10)));
-        this -> scrollBar.setHeight(((this -> height - 10) / this -> getSize()));
+        this -> scrollBar.setHeight(0);
+        this -> cursor.setVisible(false);
     }
     this -> subElements.clear();
     this -> linkElements.clear();


### PR DESCRIPTION
## Makes the checkbox filled when it should initially be checked
https://github.com/shaoxiongduan/sci-calc/pull/7/commits/09c03463df2db3c02f047626f4503b6bc2e4b0f2


在原有代码中，复选框只有在被更改`state`值 (执行`changeState()`函数) 时才会更新状态，这使得在被构造时就已经将`state`设置为`true` (构造时`bool* linkBool` == `true`) 的复选框在初始状态下没有被正确勾选 (例如V1.2 `Settings`菜单下的 `soild fill cursor` 复选框)。

修改后的代码利用 `(this -> state ? 6 : 0)` 设定初始状态下 `checkboxAni` 的目标值，使得在 `draw()` 函数中正确地被 `u8g2.drawBox()` 绘制复选框填充框。

---

In the original code, the checkbox only updates its state when the `state` value is changed (by executing the `changeState()` function). This causes an issue where checkboxes that have their `state` set to `true` during construction (when `bool* linkBool` == `true` during construction) are not correctly checked in their initial state (for example, the `solid fill cursor` checkbox in the V1.2 `Settings` menu).

The modified code sets the initial target value of `checkboxAni` using `(this->state ? 6 : 0)`, ensuring that the checkbox fill box is correctly drawn by `u8g2.drawBox()` in the `draw()` function.

## Fixed some problem of stopwatch

### fix: stopwatch don't properly resumed after pause
https://github.com/shaoxiongduan/sci-calc/pull/7/commits/adef516930b4ea3c8845d2756c80ddc12991182d

在原有代码中，暂停后的恢复会使计时器从0开始计时。修复后的秒表将记录暂停时间，并在恢复时运算暂停时走过的时间，以确保在恢复时正确从暂停前的时间开始。

https://github.com/user-attachments/assets/bd9643f2-c557-4dec-aaa0-dda33ab1718d

---

In the original code, resuming after a pause would cause the stopwatch to start counting from 0. The stopwatch will now record the pause duration and account for the elapsed time during the pause when resuming, ensuring that the timer correctly starts from the pre-pause time.

### fix: lapMenu unexpectly called enter()
https://github.com/shaoxiongduan/sci-calc/pull/7/commits/5cc156211a19003b70944d46d688e4337466b9cb

在原有代码中，如果在秒表中使用Del按键增加了lap点，那么在尝试暂停计时器时，由于lap点在被插入时赋予了意外的`linkElement`值: 

https://github.com/shaoxiongduan/sci-calc/blob/a62f8e378d40e9daa5faf9237bea039dbcf9e3d3/sci_calc_code/src/Stopwatch/StopwatchUI.cpp#L58

导致当用户按下Enter键时，尝试暂停秒表的同时也触发了lapMenu对Enter键的处理，引发了如下异常，造成设备异常重启: 
```
Guru Meditation Error: Core  1 panic'ed (Unhandled debug exception). 
Debug exception reason: Stack canary watchpoint triggered (loopTask) 
Core  1 register dump:
PC      : 0x4009896b  PS      : 0x00060636  A0      : 0x8009a6d4  A1      : 0x3ffe05f0  
A2      : 0x3ffbb66c  A3      : 0xb33fffff  A4      : 0x0000cdcd  A5      : 0x00060623  
A6      : 0x00060623  A7      : 0x0000abab  A8      : 0x0000abab  A9      : 0xffffffff  
A10     : 0x00000050  A11     : 0x00000080  A12     : 0x00000007  A13     : 0x00001800  
A14     : 0x007bb66c  A15     : 0x003fffff  SAR     : 0x00000019  EXCCAUSE: 0x00000001  
EXCVADDR: 0x00000000  LBEG    : 0x4016b0f5  LEND    : 0x4016b109  LCOUNT  : 0x00000002  


Backtrace: 0x40098968:0x3ffe05f0 ... 0x400d919e:0x3ffe1df0 |<-CONTINUES

ELF file SHA256: be67abb1b54d2307

Rebooting...
```
由此，将插入lap的方法`insertElement(UIElement* targetElement, UIElement* linkElement)` 的第二个参数修改为空指针`nullptr` 可以解决这一问题。

---

In the original code, if you use the Del key to add a lap point in the stopwatch, when you try to pause the timer, because the lap point is given an unexpected `linkElement` value when it is inserted :
https://github.com/shaoxiongduan/sci-calc/blob/a62f8e378d40e9daa5faf9237bea039dbcf9e3d3/sci_calc_code/src/Stopwatch/StopwatchUI.cpp#L58

So when the user presses the Enter key, the attempt to pause the stopwatch also triggers the lapMenu to handle the Enter key, causing the following exception, causing the device to restart abnormally:
```
Guru Meditation Error: Core  1 panic'ed (Unhandled debug exception). 
Debug exception reason: Stack canary watchpoint triggered (loopTask) 
Core  1 register dump:
PC      : 0x4009896b  PS      : 0x00060636  A0      : 0x8009a6d4  A1      : 0x3ffe05f0  
A2      : 0x3ffbb66c  A3      : 0xb33fffff  A4      : 0x0000cdcd  A5      : 0x00060623  
A6      : 0x00060623  A7      : 0x0000abab  A8      : 0x0000abab  A9      : 0xffffffff  
A10     : 0x00000050  A11     : 0x00000080  A12     : 0x00000007  A13     : 0x00001800  
A14     : 0x007bb66c  A15     : 0x003fffff  SAR     : 0x00000019  EXCCAUSE: 0x00000001  
EXCVADDR: 0x00000000  LBEG    : 0x4016b0f5  LEND    : 0x4016b109  LCOUNT  : 0x00000002  


Backtrace: 0x40098968:0x3ffe05f0 ... 0x400d919e:0x3ffe1df0 |<-CONTINUES

ELF file SHA256: be67abb1b54d2307

Rebooting...
```
Therefore, changing the second parameter of the insert lap method `insertElement(UIElement* targetElement, UIElement* linkElement)` to a null pointer `nullptr` can solve this problem.

### fix: cursor isn't clear at Menu::clear()
https://github.com/shaoxiongduan/sci-calc/pull/7/commits/8ff5f1451f5009623bd9213c6f2c4b02568e878a

在原有代码中，`Menu::clear()`函数只会清除指针位置等信息，但是却并没有隐藏光标。导致清除后光标仍然留存在菜单上。体现为Stopwatch中触发Reset后lapMenu中会留有一个无文本的cursor。

由于实在想不出更好的解决方案，因此我为Cursor类增加了一个`isVisible`变量和`setVisible(bool)`函数。可以在`Menu::clear()`时使用`setVisible(false)`来临时隐藏指针，并在下一次向labMenu中加入lab元素时重新将指针设为可见。

这个Commit 修改了很大一部分的`Menu::clear()` (原谅我实在没看懂大佬那段代码为什么要这样设计，但是看这个函数只有一个引用所以干脆就这样改了)，可能会对后续开发产生一定的影响。如果造成了困扰劳烦您修改，实在抱歉！

---

In the original code, the `Menu::clear()` function only clears information such as the pointer position, but it does not hide the cursor. As a result, after clearing, the cursor remains on the menu. This manifests in the Stopwatch where, after triggering a Reset, an empty cursor remains in the lapMenu.

Since I couldn't come up with a better solution, I added an `isVisible` variable and a `setVisible(bool)` function to the Cursor class. This allows the cursor to be temporarily hidden using `setVisible(false)` during `Menu::clear()`, and then made visible again when a new lap element is added to the lapMenu.

This commit significantly modifies `Menu::clear()`, which may impact subsequent development. I apologize for any inconvenience caused, and please feel free to make any necessary adjustments.
