### PR TITLE
Fixed a device crash when RPN SWITCH was incorrectly entered and parsed

### DIFF
--- a/sci_calc_code/src/Calculator/Calculator.cpp
+++ b/sci_calc_code/src/Calculator/Calculator.cpp
@@ -111,7 +111,7 @@ void Calculator::update() {
     else if (str == "MODE SWITCH") {
         angleMode = !angleMode;
     }
-    else if (str == "RPN") {
+    else if (str == "RPN SWITCH") {
         RPNMode = !RPNMode;
     }
     draw();

--- a/sci_calc_code/src/UIElements/InputBox.cpp
+++ b/sci_calc_code/src/UIElements/InputBox.cpp
@@ -174,7 +174,7 @@ void InputBox::update() {
         Serial.println("deleting str");
         deleteStr();
     }
-    else if ((kb.getRisingEdgeKey() != std::make_pair(-1, -1)) && ((str != "RIGHT" && str != "LEFT" && str != "UP" && str != "DOWN" && str != "LAYER SWITCH" && str != "MODE SWITCH"))) {
+    else if ((kb.getRisingEdgeKey() != std::make_pair(-1, -1)) && ((str != "RIGHT" && str != "LEFT" && str != "UP" && str != "DOWN" && str != "LAYER SWITCH" && str != "MODE SWITCH" && str != "RPN SWITCH"))) {
         Serial.println("funciwdi");
         insertStr(calcLayout.updateString());
     }


### PR DESCRIPTION
当用户在Calculator 中按下 `RPN` 按钮后，将会在表达式输入框错误地中插入字符串`RPN SWITCH`，并且没有在表达式解析前的语法正确性检查检测出问题，导致表达式解析时出现异常，造成设备崩溃: 
```
# Pressed RPN Button

funciwdi
sttr size: 10
curpos: 10

# Pressed Enter Button

Start parsing
Substring: R
Substring: RP
Substring: RPN
Substring: RPN 
Substring: RPN S
Substring: RPN SW
Substring: RPN SWI
Substring: RPN SWIT
Substring: RPN SWITC
Substring: RPN SWITCH
Syntax true 2
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x400d6062  PS      : 0x00060030  A0      : 0x800d6cb8  A1      : 0x3ffe2350
A2      : 0x3ffee3e0  A3      : 0x3ffe241c  A4      : 0x3ffd5494  A5      : 0x3ffee800
A6      : 0x000001e0  A7      : 0x3ffe2444  A8      : 0x800d6062  A9      : 0x3ffe2330  
A10     : 0x9d0875f7  A11     : 0x3ffee3e0  A12     : 0x3ffee600  A13     : 0x3ffee600
A14     : 0x3ffee5dc  A15     : 0x3ffee600  SAR     : 0x00000015  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x9d0875f7  LBEG    : 0x40091600  LEND    : 0x40091616  LCOUNT  : 0xffffffff


Backtrace: 0x400d605f:0x3ffe2350 0x400d6cb5:0x3ffe2410 0x400d3d7b:0x3ffe2480 0x400d3f05:0x3ffe24e0 0x400e2113:0x3ffe2540 0x400fab01:0x3ffe2560




ELF file SHA256: faa500612db8f4d2

Rebooting...
```

因此将 `str != "RPN SWITCH"` 加入功能键判定，使得这个按钮不会被输入到输入框中，可以解决这一问题。

但是似乎在普通Calculator 中，无法正常使用RPN语法，会提示语法错误。

---

When the user presses the `RPN` button in the Calculator, the string `RPN SWITCH` is incorrectly inserted into the expression input box. This issue is not detected by the syntax correctness check before expression parsing, leading to an exception during parsing and causing the device to crash:

```
# Pressed RPN Button

funciwdi
sttr size: 10
curpos: 10

# Pressed Enter Button

Start parsing
Substring: R
Substring: RP
Substring: RPN
Substring: RPN 
Substring: RPN S
Substring: RPN SW
Substring: RPN SWI
Substring: RPN SWIT
Substring: RPN SWITC
Substring: RPN SWITCH
Syntax true 2
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x400d6062  PS      : 0x00060030  A0      : 0x800d6cb8  A1      : 0x3ffe2350
A2      : 0x3ffee3e0  A3      : 0x3ffe241c  A4      : 0x3ffd5494  A5      : 0x3ffee800
A6      : 0x000001e0  A7      : 0x3ffe2444  A8      : 0x800d6062  A9      : 0x3ffe2330  
A10     : 0x9d0875f7  A11     : 0x3ffee3e0  A12     : 0x3ffee600  A13     : 0x3ffee600
A14     : 0x3ffee5dc  A15     : 0x3ffee600  SAR     : 0x00000015  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x9d0875f7  LBEG    : 0x40091600  LEND    : 0x40091616  LCOUNT  : 0xffffffff


Backtrace: 0x400d605f:0x3ffe2350 0x400d6cb5:0x3ffe2410 0x400d3d7b:0x3ffe2480 0x400d3f05:0x3ffe24e0 0x400e2113:0x3ffe2540 0x400fab01:0x3ffe2560




ELF file SHA256: faa500612db8f4d2

Rebooting...
```

Therefore, adding `str != "RPN SWITCH"` to the function key determination, so that this button is not entered into the input box, can solve this problem.

However, it seems that the RPN syntax cannot be used correctly in the regular Calculator, as it prompts a syntax error.